### PR TITLE
Fix type assertion for response IDs

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -198,6 +198,18 @@ func (c *Client) call(ctx context.Context, method string, params interface{}, re
 	}
 }
 
+// idToString converts an interface{} ID to a string, handling both string and json.Number types
+func idToString(id interface{}) string {
+	switch v := id.(type) {
+	case string:
+		return v
+	case json.Number:
+		return string(v)
+	default:
+		return fmt.Sprintf("%v", id)
+	}
+}
+
 // startResponseHandler starts a goroutine to handle incoming responses
 func (c *Client) startResponseHandler() {
 	go func() {
@@ -208,7 +220,7 @@ func (c *Client) startResponseHandler() {
 				return
 			}
 
-			idStr, _ := resp.ID.(string)
+			idStr := idToString(resp.ID)
 			c.mu.RLock()
 			respChan, exists := c.pending[idStr]
 			c.mu.RUnlock()

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -150,7 +150,7 @@ func TestMCPClient(t *testing.T) {
 	// Create mock responses for initialization
 	initResponse := JSONRPCResponse{
 		JSONRPC: "2.0",
-		ID:      1,
+		ID:      NewNumberID(1),
 		Result: InitializeResponse{
 			ProtocolVersion: "2024-11-05",
 			Capabilities:    map[string]interface{}{},

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -70,6 +70,8 @@ func NewStdioTransportWithEnv(command string, env map[string]string, args ...str
 		encoder: json.NewEncoder(stdin),
 		decoder: json.NewDecoder(stdout),
 	}
+	// Note: We don't use decoder.UseNumber() because our custom MCPID type
+	// handles both string and numeric IDs correctly with proper marshaling
 
 	return transport, nil
 }
@@ -147,6 +149,8 @@ func NewTCPTransport(host string, port int) (*TCPTransport, error) {
 		encoder: json.NewEncoder(conn),
 		decoder: json.NewDecoder(conn),
 	}
+	// Note: We don't use decoder.UseNumber() because our custom MCPID type
+	// handles both string and numeric IDs correctly with proper marshaling
 	return t, nil
 }
 

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -70,7 +70,6 @@ func NewStdioTransportWithEnv(command string, env map[string]string, args ...str
 		encoder: json.NewEncoder(stdin),
 		decoder: json.NewDecoder(stdout),
 	}
-	transport.decoder.UseNumber()
 
 	return transport, nil
 }
@@ -148,7 +147,6 @@ func NewTCPTransport(host string, port int) (*TCPTransport, error) {
 		encoder: json.NewEncoder(conn),
 		decoder: json.NewDecoder(conn),
 	}
-	t.decoder.UseNumber()
 	return t, nil
 }
 

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -70,8 +70,6 @@ func NewStdioTransportWithEnv(command string, env map[string]string, args ...str
 		encoder: json.NewEncoder(stdin),
 		decoder: json.NewDecoder(stdout),
 	}
-	// Note: We don't use decoder.UseNumber() because our custom MCPID type
-	// handles both string and numeric IDs correctly with proper marshaling
 
 	return transport, nil
 }
@@ -149,8 +147,6 @@ func NewTCPTransport(host string, port int) (*TCPTransport, error) {
 		encoder: json.NewEncoder(conn),
 		decoder: json.NewDecoder(conn),
 	}
-	// Note: We don't use decoder.UseNumber() because our custom MCPID type
-	// handles both string and numeric IDs correctly with proper marshaling
 	return t, nil
 }
 

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -5,25 +5,25 @@ import (
 	"fmt"
 )
 
-// MCPID represents a JSON-RPC ID that can be either a string or number
-type MCPID struct {
+// JSONRPCID represents a JSON-RPC ID that can be either a string or number
+type JSONRPCID struct {
 	isString bool
 	strVal   string
 	numVal   float64
 }
 
-// NewStringID creates an MCPID from a string
-func NewStringID(s string) MCPID {
-	return MCPID{isString: true, strVal: s}
+// NewStringID creates a JSONRPCID from a string
+func NewStringID(s string) JSONRPCID {
+	return JSONRPCID{isString: true, strVal: s}
 }
 
-// NewNumberID creates an MCPID from a number
-func NewNumberID(n float64) MCPID {
-	return MCPID{isString: false, numVal: n}
+// NewNumberID creates a JSONRPCID from a number
+func NewNumberID(n float64) JSONRPCID {
+	return JSONRPCID{isString: false, numVal: n}
 }
 
 // String returns a string representation for use as a map key
-func (id MCPID) String() string {
+func (id JSONRPCID) String() string {
 	if id.isString {
 		return id.strVal
 	}
@@ -31,7 +31,7 @@ func (id MCPID) String() string {
 }
 
 // MarshalJSON implements json.Marshaler
-func (id MCPID) MarshalJSON() ([]byte, error) {
+func (id JSONRPCID) MarshalJSON() ([]byte, error) {
 	if id.isString {
 		return json.Marshal(id.strVal)
 	}
@@ -39,7 +39,7 @@ func (id MCPID) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler
-func (id *MCPID) UnmarshalJSON(data []byte) error {
+func (id *JSONRPCID) UnmarshalJSON(data []byte) error {
 	// Try string first
 	var strVal string
 	if err := json.Unmarshal(data, &strVal); err == nil {
@@ -60,14 +60,14 @@ func (id *MCPID) UnmarshalJSON(data []byte) error {
 // JSON-RPC 2.0 message types
 type JSONRPCRequest struct {
 	JSONRPC string      `json:"jsonrpc"`
-	ID      MCPID       `json:"id"`
+	ID      JSONRPCID   `json:"id"`
 	Method  string      `json:"method"`
 	Params  interface{} `json:"params,omitempty"`
 }
 
 type JSONRPCResponse struct {
 	JSONRPC string      `json:"jsonrpc"`
-	ID      MCPID       `json:"id"`
+	ID      JSONRPCID   `json:"id"`
 	Result  interface{} `json:"result,omitempty"`
 	Error   *JSONRPCError `json:"error,omitempty"`
 }


### PR DESCRIPTION
Introduce `JSONRPCID` type to correctly handle JSON-RPC IDs.

Fixes a client timeout bug where numeric JSON-RPC IDs were dropped, and ensures compliance with the JSON-RPC 2.0 specification which requires responses to preserve the original ID's type (string or number).