### PR TITLE
add summary auto for responses api

### DIFF
--- a/openai/responses.go
+++ b/openai/responses.go
@@ -192,7 +192,8 @@ func (m *ResponsesAPI) Generate(
 
 	if m.reasoningEffort != "" {
 		payload["reasoning"] = map[string]any{
-			"effort": m.reasoningEffort,
+			"effort":  m.reasoningEffort,
+			"summary": "auto",
 		}
 	}
 


### PR DESCRIPTION
I think we need this to get reasoning tokens back from OpenAI:

https://platform.openai.com/docs/guides/reasoning#reasoning-summaries

> Reasoning summary output is part of the summary array in the reasoning [output item](https://platform.openai.com/docs/api-reference/responses/object#responses/object-output). This output will not be included unless you explicitly opt in to including reasoning summaries.